### PR TITLE
Modernize integration to HA 2024/2025 standards

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,7 +49,7 @@ configuration.yaml: notify: platform: notify_mqtt
 ### Config-entry path (new)
 - `MqttNotifyEntity` inherits from `NotifyEntity`; implements `async_send_message(message, title=None)`.
 - `_attr_supported_features = NotifyEntityFeature.TITLE` signals title support to HA.
-- The entity instance is stored in `entry.runtime_data` so the custom service handler in `__init__.py` can retrieve it without going through `hass.data`.
+- The entity instance is stored in `hass.data[DOMAIN]` keyed by `entry.entry_id` so the custom service handler in `__init__.py` can retrieve it.
 - MQTT is published via `await mqtt.async_publish(hass, topic, payload)`.
 
 ### YAML-legacy path (kept for backward compat)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 This is a Home Assistant custom component that bridges HA's notification system to MQTT. When a notification is sent via this platform, it serializes the payload to JSON and publishes it to a configured MQTT topic — enabling consumption by Node-RED or any MQTT-aware system.
 
-Distributed via [HACS](https://hacs.xyz/). Minimum supported Home Assistant version: 0.103.
+Distributed via [HACS](https://hacs.xyz/). Minimum supported Home Assistant version: 2023.4.0.
 
 ## Architecture
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,97 @@
+# Copilot Instructions
+
+## Project Overview
+
+This is a Home Assistant custom component that bridges HA's notification system to MQTT. When a notification is sent via this platform, it serializes the payload to JSON and publishes it to a configured MQTT topic — enabling consumption by Node-RED or any MQTT-aware system.
+
+Distributed via [HACS](https://hacs.xyz/). Minimum supported Home Assistant version: 0.103.
+
+## Architecture
+
+Two parallel setup paths exist in the same codebase:
+
+```
+── UI / Config Flow path ──────────────────────────────────────────────
+ConfigFlow (config_flow.py)
+    → stores topic in ConfigEntry
+    → async_setup_entry (__init__.py)
+        → forwards to notify platform → MqttNotifyEntity (notify.py)
+            → notify.send_message  (message + title only)
+        → registers notify_mqtt.publish service (__init__.py)
+            → _build_payload(message, title, data) → mqtt.async_publish
+
+── YAML / Legacy path ─────────────────────────────────────────────────
+configuration.yaml: notify: platform: notify_mqtt
+    → get_service (notify.py)
+        → MqttNotificationService (notify.py)
+            → notify.NAME  (message + title + target + data dict)
+                → _build_payload → mqtt.async_publish
+```
+
+`_build_payload()` in `notify.py` is the single shared serialization helper used by all paths.
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `custom_components/notify_mqtt/notify.py` | Both platforms: `MqttNotifyEntity` (config entry), `MqttNotificationService` (YAML legacy), `_build_payload` helper |
+| `custom_components/notify_mqtt/__init__.py` | `async_setup_entry` / `async_unload_entry`; registers `notify_mqtt.publish` custom service |
+| `custom_components/notify_mqtt/config_flow.py` | Single-step config flow: prompts for MQTT topic, validates with `valid_publish_topic` |
+| `custom_components/notify_mqtt/const.py` | `DOMAIN`, `CONF_TOPIC` constants |
+| `custom_components/notify_mqtt/manifest.json` | Integration metadata: `config_flow: true`, `iot_class: local_push`, `integration_type: service` |
+| `custom_components/notify_mqtt/services.yaml` | Defines `notify_mqtt.publish` custom service with `entity_id`, `message`, `title`, `data` fields |
+| `custom_components/notify_mqtt/strings.json` | Config flow UI strings (source of truth) |
+| `custom_components/notify_mqtt/translations/en.json` | English translations (mirrors strings.json) |
+| `hacs.json` | HACS store metadata |
+
+## Home Assistant Integration Conventions
+
+### Config-entry path (new)
+- `MqttNotifyEntity` inherits from `NotifyEntity`; implements `async_send_message(message, title=None)`.
+- `_attr_supported_features = NotifyEntityFeature.TITLE` signals title support to HA.
+- The entity instance is stored in `entry.runtime_data` so the custom service handler in `__init__.py` can retrieve it without going through `hass.data`.
+- MQTT is published via `await mqtt.async_publish(hass, topic, payload)`.
+
+### YAML-legacy path (kept for backward compat)
+- `MqttNotificationService` inherits from `BaseNotificationService`; implements `async_send_message(message, **kwargs)`.
+- `PLATFORM_SCHEMA` extends HA's base with `vol.Required(CONF_TOPIC): valid_publish_topic`.
+- `get_service(hass, config, discovery_info=None)` is the factory HA calls.
+- Supports full payload: `message`, `title`, `target`, and `data` dict (merged top-level).
+
+### Custom service + multi-entry
+- `notify_mqtt.publish` is registered on the **first** `async_setup_entry` call and removed only when the **last** entry is unloaded (`hass.data[DOMAIN]` is empty).
+- All active entities are stored in `hass.data[DOMAIN]` keyed by `entry.entry_id`; the service handler resolves the target by matching `entity.entity_id` across all entries.
+- This means multiple topics (multiple config entries) all work correctly with one shared service registration.
+
+### Config flow
+- `ConfigFlow` subclass in `config_flow.py`; `domain=DOMAIN` passed to class decorator.
+- `unique_id` = the MQTT topic string (prevents duplicate entries for the same topic).
+- Error key `"invalid_topic"` maps to the string in `strings.json`.
+- `NotifyMqttOptionsFlow` handles editing an existing entry (topic + name); registered via `async_get_options_flow`.
+- On options save, `_async_options_updated` triggers `async_reload` so the entity immediately reflects the new values.
+- The entity reads effective config as `{**entry.data, **entry.options}` so options always override the original data.
+
+## Configuration
+
+### UI (recommended)
+Settings → Devices & Services → Add Integration → Notify MQTT → enter topic.
+
+### YAML (legacy)
+```yaml
+notify:
+  - name: NOTIFIER_NAME       # optional, defaults to "notify"
+    platform: notify_mqtt
+    topic: some/mqtt/topic    # required
+```
+
+## JSON Payload Format
+
+All paths produce the same format:
+```json
+{
+  "message": "...",
+  "title": "...",        // if provided
+  "target": "...",       // YAML path only
+  "key": "value"         // any data dict keys, merged top-level
+}
+```

--- a/README.md
+++ b/README.md
@@ -2,25 +2,137 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 
-The `notify_mqtt` notification platform allows you to publish notifications from Home Assistant to an MQTT topic. This is primarily intended to help those who have an existing notification infrastructure set up in [Node-RED](https://nodered.org/) or another MQTT-friendly tool, but may find other uses.
+The `notify_mqtt` integration publishes Home Assistant notifications to an MQTT topic as a JSON payload. It is primarily intended for use with [Node-RED](https://nodered.org/) or any other MQTT-aware system that consumes notification events.
 
-To enable the `notify_mqtt` notification platform in your installation, add the following to your `configuration.yaml` file:
+---
+
+## Installation
+
+Install via [HACS](https://hacs.xyz/) as a custom repository, or copy the `custom_components/notify_mqtt` directory into your Home Assistant `custom_components` folder.
+
+---
+
+## Setup (UI — recommended)
+
+1. Go to **Settings → Devices & Services → Add Integration** and search for **Notify MQTT**.
+2. Enter the MQTT topic to publish to (e.g. `home/notifications/alerts`) and an optional friendly name.
+3. Repeat to add as many topics as you need.
+
+Each configured topic becomes a `notify` entity. The entity's name (and therefore its service name, e.g. `notify.garage_alerts`) comes from the friendly name you set; if none is set, the topic string is used.
+
+To change the topic or rename an entry after setup, go to **Settings → Devices & Services**, find the entry, and click **Configure**.
 
 ```yaml
-# Example configuration.yaml entry
+service: notify.send_message
+target:
+  entity_id: notify.home_notifications_alerts
+data:
+  message: The garage door has been open for 10 minutes.
+  title: Garage Alert
+```
+
+The published MQTT payload will be:
+
+```json
+{"message": "The garage door has been open for 10 minutes.", "title": "Garage Alert"}
+```
+
+### Sending extra data (UI-configured instances)
+
+The standard `notify.send_message` service only supports `message` and `title`. If you need to merge additional keys into the JSON payload (e.g. routing hints, severity, icons), use the `notify_mqtt.publish` service instead:
+
+```yaml
+service: notify_mqtt.publish
+data:
+  entity_id: notify.home_notifications_alerts
+  message: The garage door has been open for 10 minutes.
+  title: Garage Alert
+  data:
+    severity: high
+    room: kitchen
+    icon: mdi:garage
+```
+
+The published MQTT payload will be:
+
+```json
+{
+  "message": "The garage door has been open for 10 minutes.",
+  "title": "Garage Alert",
+  "severity": "high",
+  "room": "kitchen",
+  "icon": "mdi:garage"
+}
+```
+
+---
+
+## Setup (YAML — legacy, kept for backward compatibility)
+
+Add the following to your `configuration.yaml`:
+
+```yaml
 notify:
   - name: NOTIFIER_NAME
     platform: notify_mqtt
-    topic: MQTT/TOPIC
+    topic: home/notifications/alerts
 ```
 
-**name:** Setting the optional parameter `name` allows multiple notifiers to be created. The notifier will bind to the service `notify.NOTIFIER_NAME`.
-  * required: false
-  * default: notify
-  * type: string
+**`name`** (optional, default: `notify`): Creates the service `notify.NOTIFIER_NAME`.
 
-**topic:** The MQTT topic that will receive the notification.
-  * required: true
-  * type: string
+**`topic`** (required): The MQTT topic to publish to.
 
-Notifications will be delivered to the MQTT topic as a string representation of a JSON object containing the message, title, and other data send to the notification service.
+YAML-configured instances support the full `data:` dict (top-level merge) and `target:` field via the standard `notify.NOTIFIER_NAME` service, exactly as before:
+
+```yaml
+service: notify.NOTIFIER_NAME
+data:
+  message: The garage door has been open for 10 minutes.
+  title: Garage Alert
+  data:
+    severity: high
+    room: kitchen
+```
+
+---
+
+## Breaking changes in v1.0.0
+
+This release introduces UI-based configuration and migrates the integration to the current Home Assistant standards. **Existing YAML configurations continue to work without any changes.**
+
+### What changed
+
+| | Before (v0.x) | After (v1.0.0) |
+|---|---|---|
+| **Setup** | YAML `notify:` block only | UI (recommended) or YAML |
+| **YAML config** | Supported | Still supported (unchanged) |
+| **`data:` dict (top-level merge)** | Supported via `notify.NAME` | YAML: unchanged · UI: use `notify_mqtt.publish` |
+| **`target:` field** | Echoed into payload | YAML: unchanged · UI: not available |
+| **MQTT publish API** | `hass.components.mqtt.publish` (deprecated) | `mqtt.async_publish` (current) |
+
+### Migrating from YAML to UI setup
+
+If you want to switch an existing YAML-configured notifier to UI setup:
+
+1. Add it via **Settings → Devices & Services → Add Integration → Notify MQTT**.
+2. In your automations, replace:
+   ```yaml
+   service: notify.MY_NOTIFIER_NAME
+   data:
+     message: Hello
+     data:
+       severity: high
+   ```
+   with:
+   ```yaml
+   service: notify_mqtt.publish
+   data:
+     entity_id: notify.home_notifications_alerts   # entity name = your topic
+     message: Hello
+     data:
+       severity: high
+   ```
+3. Remove the old `notify:` block from `configuration.yaml` and restart.
+
+You do **not** have to migrate — YAML configuration will continue to work.
+

--- a/custom_components/notify_mqtt/__init__.py
+++ b/custom_components/notify_mqtt/__init__.py
@@ -1,2 +1,87 @@
 """The Notify MQTT integration."""
+from __future__ import annotations
 
+from typing import Any
+
+from homeassistant.components import mqtt
+from homeassistant.components.notify import ATTR_MESSAGE, ATTR_TITLE
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+
+from .const import CONF_TOPIC, DOMAIN
+
+PLATFORMS = [Platform.NOTIFY]
+
+SERVICE_PUBLISH = "publish"
+ATTR_DATA = "data"
+
+SERVICE_PUBLISH_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Required(ATTR_MESSAGE): cv.string,
+        vol.Optional(ATTR_TITLE): cv.string,
+        vol.Optional(ATTR_DATA): dict,
+    }
+)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Notify MQTT from a config entry."""
+    # hass.data[DOMAIN] maps entry_id → MqttNotifyEntity for all active entries.
+    hass.data.setdefault(DOMAIN, {})
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
+
+    # Register the custom service once; subsequent entries reuse the same handler.
+    if not hass.services.has_service(DOMAIN, SERVICE_PUBLISH):
+
+        async def handle_publish(call: ServiceCall) -> None:
+            """Handle the notify_mqtt.publish service call."""
+            from .notify import _build_payload  # local import avoids circular dep
+
+            entity_id: str = call.data["entity_id"]
+            entity = next(
+                (e for e in hass.data[DOMAIN].values() if e.entity_id == entity_id),
+                None,
+            )
+            if entity is None:
+                raise ServiceValidationError(
+                    f"No active notify_mqtt entity with entity_id '{entity_id}'"
+                )
+            payload = _build_payload(
+                call.data[ATTR_MESSAGE],
+                call.data.get(ATTR_TITLE),
+                data=call.data.get(ATTR_DATA),
+            )
+            await mqtt.async_publish(hass, entity.topic, payload)
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_PUBLISH,
+            handle_publish,
+            schema=SERVICE_PUBLISH_SCHEMA,
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unloaded:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+        # Remove the shared service only when the last entry is unloaded.
+        if not hass.data[DOMAIN]:
+            hass.services.async_remove(DOMAIN, SERVICE_PUBLISH)
+    return unloaded
+
+
+async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the config entry when options are updated."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/notify_mqtt/__init__.py
+++ b/custom_components/notify_mqtt/__init__.py
@@ -1,8 +1,6 @@
 """The Notify MQTT integration."""
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components import mqtt
 from homeassistant.components.notify import ATTR_MESSAGE, ATTR_TITLE
 from homeassistant.config_entries import ConfigEntry
@@ -12,7 +10,7 @@ from homeassistant.exceptions import ServiceValidationError
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 
-from .const import CONF_TOPIC, DOMAIN
+from .const import DOMAIN
 
 PLATFORMS = [Platform.NOTIFY]
 

--- a/custom_components/notify_mqtt/config_flow.py
+++ b/custom_components/notify_mqtt/config_flow.py
@@ -1,0 +1,112 @@
+"""Config flow for Notify MQTT."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.mqtt import valid_publish_topic
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
+from homeassistant.core import callback
+from homeassistant.helpers import selector
+
+from .const import CONF_NAME, CONF_TOPIC, DOMAIN
+
+
+def _topic_name_schema(
+    default_topic: str = "", default_name: str = ""
+) -> vol.Schema:
+    return vol.Schema(
+        {
+            vol.Required(CONF_TOPIC, default=default_topic): selector.selector({"text": {}}),
+            vol.Optional(CONF_NAME, default=default_name): selector.selector({"text": {}}),
+        }
+    )
+
+
+def _entry_title(user_input: dict[str, Any]) -> str:
+    """Derive a config entry title from user input."""
+    name = (user_input.get(CONF_NAME) or "").strip()
+    return name if name else user_input[CONF_TOPIC]
+
+
+def _validate_topic(user_input: dict[str, Any]) -> dict[str, str]:
+    """Return an errors dict; empty means valid."""
+    try:
+        valid_publish_topic(user_input[CONF_TOPIC])
+    except vol.Invalid:
+        return {CONF_TOPIC: "invalid_topic"}
+    return {}
+
+
+class NotifyMqttConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Notify MQTT."""
+
+    VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> NotifyMqttOptionsFlow:
+        """Return the options flow handler."""
+        return NotifyMqttOptionsFlow(config_entry)
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial configuration step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            errors = _validate_topic(user_input)
+            if not errors:
+                await self.async_set_unique_id(user_input[CONF_TOPIC])
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=_entry_title(user_input),
+                    data=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=_topic_name_schema(),
+            errors=errors,
+        )
+
+
+class NotifyMqttOptionsFlow(OptionsFlow):
+    """Handle options for an existing Notify MQTT entry."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Store the config entry for use in the flow step."""
+        self._entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage options — topic and friendly name."""
+        errors: dict[str, str] = {}
+
+        # Read current effective values (options override data).
+        current = {**self._entry.data, **self._entry.options}
+        current_topic: str = current.get(CONF_TOPIC, "")
+        current_name: str = current.get(CONF_NAME, "")
+
+        if user_input is not None:
+            errors = _validate_topic(user_input)
+            if not errors:
+                # Strip empty name so it doesn't shadow the topic fallback.
+                cleaned = {CONF_TOPIC: user_input[CONF_TOPIC]}
+                name = (user_input.get(CONF_NAME) or "").strip()
+                if name:
+                    cleaned[CONF_NAME] = name
+                return self.async_create_entry(
+                    title=name or cleaned[CONF_TOPIC],
+                    data=cleaned,
+                )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=_topic_name_schema(current_topic, current_name),
+            errors=errors,
+        )
+

--- a/custom_components/notify_mqtt/config_flow.py
+++ b/custom_components/notify_mqtt/config_flow.py
@@ -94,13 +94,26 @@ class NotifyMqttOptionsFlow(OptionsFlow):
         if user_input is not None:
             errors = _validate_topic(user_input)
             if not errors:
+                new_topic: str = user_input[CONF_TOPIC]
+                # Check for duplicate topic across other config entries.
+                if new_topic != current_topic:
+                    for entry in self.hass.config_entries.async_entries(DOMAIN):
+                        if entry.entry_id != self._entry.entry_id and entry.unique_id == new_topic:
+                            errors[CONF_TOPIC] = "already_configured"
+                            break
+            if not errors:
                 # Strip empty name so it doesn't shadow the topic fallback.
-                cleaned = {CONF_TOPIC: user_input[CONF_TOPIC]}
+                cleaned = {CONF_TOPIC: new_topic}
                 name = (user_input.get(CONF_NAME) or "").strip()
                 if name:
                     cleaned[CONF_NAME] = name
+                # Keep unique_id in sync with the topic.
+                if new_topic != current_topic:
+                    self.hass.config_entries.async_update_entry(
+                        self._entry, unique_id=new_topic
+                    )
                 return self.async_create_entry(
-                    title=name or cleaned[CONF_TOPIC],
+                    title=name or new_topic,
                     data=cleaned,
                 )
 

--- a/custom_components/notify_mqtt/const.py
+++ b/custom_components/notify_mqtt/const.py
@@ -1,0 +1,5 @@
+"""Constants for Notify MQTT."""
+
+DOMAIN = "notify_mqtt"
+CONF_TOPIC = "topic"
+CONF_NAME = "name"

--- a/custom_components/notify_mqtt/manifest.json
+++ b/custom_components/notify_mqtt/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "notify_mqtt",
   "name": "Notify MQTT",
-  "codeowners": ["@cerebrate"]
+  "codeowners": ["@cerebrate"],
   "config_flow": true,
   "dependencies": ["mqtt"],
   "documentation": "https://github.com/cerebrate/notify_mqtt",
   "integration_type": "service",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "1.0.0",
+  "version": "1.0.0"
 }

--- a/custom_components/notify_mqtt/manifest.json
+++ b/custom_components/notify_mqtt/manifest.json
@@ -1,9 +1,12 @@
 {
   "domain": "notify_mqtt",
   "name": "Notify MQTT",
-  "version": "0.1.1",
-  "documentation": "",
+  "version": "1.0.0",
+  "documentation": "https://github.com/cerebrate/notify_mqtt",
   "requirements": [],
   "dependencies": ["mqtt"],
+  "config_flow": true,
+  "integration_type": "service",
+  "iot_class": "local_push",
   "codeowners": ["@cerebrate"]
 }

--- a/custom_components/notify_mqtt/manifest.json
+++ b/custom_components/notify_mqtt/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "notify_mqtt",
   "name": "Notify MQTT",
-  "version": "1.0.0",
-  "documentation": "https://github.com/cerebrate/notify_mqtt",
-  "requirements": [],
-  "dependencies": ["mqtt"],
+  "codeowners": ["@cerebrate"]
   "config_flow": true,
+  "dependencies": ["mqtt"],
+  "documentation": "https://github.com/cerebrate/notify_mqtt",
   "integration_type": "service",
   "iot_class": "local_push",
-  "codeowners": ["@cerebrate"]
+  "requirements": [],
+  "version": "1.0.0",
 }

--- a/custom_components/notify_mqtt/notify.py
+++ b/custom_components/notify_mqtt/notify.py
@@ -1,9 +1,13 @@
 """Support for MQTT notification."""
+from __future__ import annotations
+
 import json
 import logging
+from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.components import mqtt
 from homeassistant.components.mqtt import valid_publish_topic
 from homeassistant.components.notify import (
     ATTR_DATA,
@@ -12,44 +16,130 @@ from homeassistant.components.notify import (
     ATTR_TITLE,
     PLATFORM_SCHEMA,
     BaseNotificationService,
+    NotifyEntity,
+    NotifyEntityFeature,
 )
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-CONF_TOPIC_NAME = "topic"
-
-PLATFORM_SCHEMA = vol.All(
-    PLATFORM_SCHEMA.extend(
-        {vol.Required(CONF_TOPIC_NAME): valid_publish_topic,}  # noqa: E231
-    ),
-)
+from .const import CONF_NAME, CONF_TOPIC, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Legacy YAML platform (kept for backward compatibility)
+# ---------------------------------------------------------------------------
 
-def get_service(hass, config, discovery_info=None):
-    """Get the notification service."""
+PLATFORM_SCHEMA = vol.All(
+    PLATFORM_SCHEMA.extend(
+        {vol.Required(CONF_TOPIC): valid_publish_topic}
+    )
+)
 
-    return MqttNotificationService(config)
+
+def get_service(
+    hass: HomeAssistant,
+    config: ConfigType,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> MqttNotificationService:
+    """Return the legacy notification service (YAML-configured instances)."""
+    topic = (discovery_info or config)[CONF_TOPIC]
+    return MqttNotificationService(hass, topic)
 
 
 class MqttNotificationService(BaseNotificationService):
-    """Implement the notification service for the MQTT topic."""
+    """Legacy notify service — used for YAML-configured instances.
 
-    def __init__(self, config):
+    Supports the full payload: message, title, target, and an arbitrary
+    data dict whose keys are merged at the top level of the JSON object
+    published to the configured MQTT topic.
+    """
+
+    def __init__(self, hass: HomeAssistant, topic: str) -> None:
         """Initialize the service."""
-        self.topic = config[CONF_TOPIC_NAME]
+        self.hass = hass
+        self.topic = topic
 
-    async def async_send_message(self, message, **kwargs):
-        """Send a message."""
-        dto = {ATTR_MESSAGE: message}
+    async def async_send_message(self, message: str = "", **kwargs: Any) -> None:
+        """Publish a notification as a JSON string to the MQTT topic."""
+        payload = _build_payload(message, kwargs.get(ATTR_TITLE), kwargs.get(ATTR_TARGET), kwargs.get(ATTR_DATA))
+        await mqtt.async_publish(self.hass, self.topic, payload)
 
-        if ATTR_TITLE in kwargs:
-            dto[ATTR_TITLE] = kwargs[ATTR_TITLE]
-        if ATTR_TARGET in kwargs:
-            dto[ATTR_TARGET] = kwargs[ATTR_TARGET]
 
-        data = kwargs.get(ATTR_DATA)
-        if data:
-            dto.update(data)
+# ---------------------------------------------------------------------------
+# Modern entity platform (config-entry-configured instances)
+# ---------------------------------------------------------------------------
 
-        topic_message = json.dumps(dto)
-        self.hass.components.mqtt.publish(self.hass, self.topic, topic_message)
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up a notify entity from a config entry."""
+    entity = MqttNotifyEntity(entry)
+    async_add_entities([entity])
+    # Register in the shared hass.data registry so __init__.handle_publish
+    # can locate this entity by entity_id across all active entries.
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entity
+
+
+class MqttNotifyEntity(NotifyEntity):
+    """Notify entity for config-entry-configured instances.
+
+    Integrates with Home Assistant's standard notify.send_message service
+    (supports message and title).  For full payload control — including an
+    arbitrary data dict merged at the top level — use the custom
+    notify_mqtt.publish service instead.
+    """
+
+    _attr_supported_features = NotifyEntityFeature.TITLE
+    _attr_has_entity_name = False
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize the entity."""
+        config = {**entry.data, **entry.options}
+        self._topic: str = config[CONF_TOPIC]
+        name = (config.get(CONF_NAME) or "").strip()
+        self._attr_name = name if name else self._topic
+        # Use entry_id as unique_id so it stays stable if topic/name change.
+        self._attr_unique_id = entry.entry_id
+
+    async def async_send_message(self, message: str, title: str | None = None) -> None:
+        """Publish a notification to the configured MQTT topic."""
+        payload = _build_payload(message, title)
+        await mqtt.async_publish(self.hass, self._topic, payload)
+
+    @property
+    def topic(self) -> str:
+        """Return the configured MQTT topic."""
+        return self._topic
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_payload(
+    message: str,
+    title: str | None = None,
+    target: Any = None,
+    data: dict[str, Any] | None = None,
+) -> str:
+    """Serialize notification fields to a JSON string.
+
+    Keys present in *data* are merged at the top level of the returned
+    object, matching the behaviour users of the legacy platform relied on.
+    """
+    dto: dict[str, Any] = {ATTR_MESSAGE: message}
+    if title is not None:
+        dto[ATTR_TITLE] = title
+    if target is not None:
+        dto[ATTR_TARGET] = target
+    if data:
+        dto.update(data)
+    return json.dumps(dto)
+

--- a/custom_components/notify_mqtt/notify.py
+++ b/custom_components/notify_mqtt/notify.py
@@ -65,6 +65,7 @@ class MqttNotificationService(BaseNotificationService):
     async def async_send_message(self, message: str = "", **kwargs: Any) -> None:
         """Publish a notification as a JSON string to the MQTT topic."""
         payload = _build_payload(message, kwargs.get(ATTR_TITLE), kwargs.get(ATTR_TARGET), kwargs.get(ATTR_DATA))
+        _LOGGER.debug("Publishing notification to %s: %s", self.topic, payload)
         await mqtt.async_publish(self.hass, self.topic, payload)
 
 
@@ -110,6 +111,7 @@ class MqttNotifyEntity(NotifyEntity):
     async def async_send_message(self, message: str, title: str | None = None) -> None:
         """Publish a notification to the configured MQTT topic."""
         payload = _build_payload(message, title)
+        _LOGGER.debug("Publishing notification to %s: %s", self._topic, payload)
         await mqtt.async_publish(self.hass, self._topic, payload)
 
     @property

--- a/custom_components/notify_mqtt/services.yaml
+++ b/custom_components/notify_mqtt/services.yaml
@@ -1,17 +1,41 @@
 # Describes the format for available notification services
 
 notify_mqtt:
-  description: Send a notification via MQTT. Fields are converted into matching fields in a JSON object sent as a string to the configured topic.
+  description: >
+    Send a notification via MQTT with full payload control.
+    All fields are serialized into a JSON object published to the
+    topic configured for the given notify entity. Unlike the standard
+    notify.send_message service, this service supports an arbitrary
+    data dictionary whose keys are merged at the top level of the
+    published JSON — matching the behaviour of the legacy YAML platform.
   fields:
+    entity_id:
+      description: The notify_mqtt entity to publish through.
+      example: notify.mqtt_notifications
+      required: true
+      selector:
+        entity:
+          integration: notify_mqtt
     message:
       description: Message body of the notification.
       example: The garage door has been open for 10 minutes.
+      required: true
+      selector:
+        text:
     title:
       description: Optional title for your notification.
-      example: 'Your Garage Door Friend'
-    target:
-      description: An array of targets to send the notification to. Optional depending on the platform.
-      example: platform specific
+      example: Your Garage Door Friend
+      selector:
+        text:
     data:
-      description: Extended information for notification. Optional depending on the platform.
-      example: platform specific
+      description: >
+        Optional dictionary of extra keys to merge into the top-level
+        JSON payload. Use this to pass routing hints, severity levels,
+        icons, or any metadata consumed by your MQTT subscribers
+        (e.g. Node-RED flows).
+      example:
+        severity: high
+        room: kitchen
+        icon: mdi:garage
+      selector:
+        object:

--- a/custom_components/notify_mqtt/services.yaml
+++ b/custom_components/notify_mqtt/services.yaml
@@ -1,6 +1,6 @@
 # Describes the format for available notification services
 
-notify_mqtt:
+publish:
   description: >
     Send a notification via MQTT with full payload control.
     All fields are serialized into a JSON object published to the

--- a/custom_components/notify_mqtt/strings.json
+++ b/custom_components/notify_mqtt/strings.json
@@ -15,7 +15,7 @@
       }
     },
     "error": {
-      "invalid_topic": "Invalid MQTT topic. Topics must not be empty and must not contain wildcard characters (# or *).",
+      "invalid_topic": "Invalid MQTT topic. Topics must not be empty and must not contain wildcard characters (# or +).",
       "already_configured": "This MQTT topic is already configured."
     },
     "abort": {
@@ -37,7 +37,8 @@
       }
     },
     "error": {
-      "invalid_topic": "Invalid MQTT topic. Topics must not be empty and must not contain wildcard characters (# or *)."
+      "invalid_topic": "Invalid MQTT topic. Topics must not be empty and must not contain wildcard characters (# or +).",
+      "already_configured": "This MQTT topic is already configured."
     }
   }
 }

--- a/custom_components/notify_mqtt/strings.json
+++ b/custom_components/notify_mqtt/strings.json
@@ -1,0 +1,43 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up MQTT Notification",
+        "description": "Enter the MQTT topic to publish notifications to. You can add multiple entries for different topics.",
+        "data": {
+          "topic": "MQTT topic",
+          "name": "Friendly name"
+        },
+        "data_description": {
+          "topic": "The MQTT topic to publish JSON notification payloads to (e.g. home/notifications/alerts).",
+          "name": "Optional display name for this notifier. If left blank, the topic is used as the name."
+        }
+      }
+    },
+    "error": {
+      "invalid_topic": "Invalid MQTT topic. Topics must not be empty and must not contain wildcard characters (# or *).",
+      "already_configured": "This MQTT topic is already configured."
+    },
+    "abort": {
+      "already_configured": "This MQTT topic is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Update MQTT Notification",
+        "data": {
+          "topic": "MQTT topic",
+          "name": "Friendly name"
+        },
+        "data_description": {
+          "topic": "The MQTT topic to publish JSON notification payloads to.",
+          "name": "Optional display name. If left blank, the topic is used as the name."
+        }
+      }
+    },
+    "error": {
+      "invalid_topic": "Invalid MQTT topic. Topics must not be empty and must not contain wildcard characters (# or *)."
+    }
+  }
+}

--- a/custom_components/notify_mqtt/translations/en.json
+++ b/custom_components/notify_mqtt/translations/en.json
@@ -15,7 +15,7 @@
       }
     },
     "error": {
-      "invalid_topic": "Invalid MQTT topic. Topics must not be empty and must not contain wildcard characters (# or *).",
+      "invalid_topic": "Invalid MQTT topic. Topics must not be empty and must not contain wildcard characters (# or +).",
       "already_configured": "This MQTT topic is already configured."
     },
     "abort": {
@@ -37,7 +37,8 @@
       }
     },
     "error": {
-      "invalid_topic": "Invalid MQTT topic. Topics must not be empty and must not contain wildcard characters (# or *)."
+      "invalid_topic": "Invalid MQTT topic. Topics must not be empty and must not contain wildcard characters (# or +).",
+      "already_configured": "This MQTT topic is already configured."
     }
   }
 }

--- a/custom_components/notify_mqtt/translations/en.json
+++ b/custom_components/notify_mqtt/translations/en.json
@@ -1,0 +1,43 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up MQTT Notification",
+        "description": "Enter the MQTT topic to publish notifications to. You can add multiple entries for different topics.",
+        "data": {
+          "topic": "MQTT topic",
+          "name": "Friendly name"
+        },
+        "data_description": {
+          "topic": "The MQTT topic to publish JSON notification payloads to (e.g. home/notifications/alerts).",
+          "name": "Optional display name for this notifier. If left blank, the topic is used as the name."
+        }
+      }
+    },
+    "error": {
+      "invalid_topic": "Invalid MQTT topic. Topics must not be empty and must not contain wildcard characters (# or *).",
+      "already_configured": "This MQTT topic is already configured."
+    },
+    "abort": {
+      "already_configured": "This MQTT topic is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Update MQTT Notification",
+        "data": {
+          "topic": "MQTT topic",
+          "name": "Friendly name"
+        },
+        "data_description": {
+          "topic": "The MQTT topic to publish JSON notification payloads to.",
+          "name": "Optional display name. If left blank, the topic is used as the name."
+        }
+      }
+    },
+    "error": {
+      "invalid_topic": "Invalid MQTT topic. Topics must not be empty and must not contain wildcard characters (# or *)."
+    }
+  }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "MQTT Notification Service",
   "render_readme": true,
-  "homeassistant": "0.103",
+  "homeassistant": "2023.4.0"
 }


### PR DESCRIPTION
- Add config flow (UI setup via Settings → Devices & Services)
- Add options flow to edit topic and friendly name after setup
- Add NotifyEntity (config-entry path) alongside legacy BaseNotificationService (YAML path, kept for backward compat)
- Add notify_mqtt.publish custom service for full data-dict payload support on config-entry instances
- Multi-entry support: shared service registration, entities tracked in hass.data[DOMAIN]
- Replace deprecated hass.components.mqtt.publish with mqtt.async_publish
- Add const.py, config_flow.py, strings.json, translations/en.json
- Update manifest.json: config_flow, iot_class, integration_type, version 1.0.0
- Update services.yaml to current HA format with selectors
- Update README with UI setup guide, notify_mqtt.publish usage, and v1.0.0 breaking changes
- Update .github/copilot-instructions.md to reflect new architecture